### PR TITLE
Remove use of access() and unistd.h

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -1,5 +1,3 @@
-#include <unistd.h>
-
 #include "input.h"
 #include "error.h"
 
@@ -7,11 +5,10 @@ FILE *file;
 
 void open_file(const char *filename)
 {
-	if (access(filename, F_OK ) == -1) {
-    	fatal_error("Input: File doesn't exist!");
+	file = fopen(filename, "rb");
+	if (file == NULL) {
+		fatal_error("Input: File doesn't exist!");
 	}
-
-	file = fopen(filename, "r");
 }
 
 FILE *get_file()


### PR DESCRIPTION
Calling `access()` here is both superfluous and racy. Also open the file in binary mode to avoid any implementation-defined text translation.