### PR TITLE
Edited the EBNF description to better reflect the top-down parsing seen in the code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ WRITE hypsquare
 ## The language description in [EBNF](https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_form):
 ```
 program = expr, ";", { program } ;
-expr = id, "=", expr | ("+"|"-"), term, { ("+"|"-"), term } ;
+expr = id, "=", expr | term, { ("+"|"-"), term } ;
 term = factor, { ("*"|"/"), factor } ;
-factor = "id" | "num" | (expr) ;
+factor = "id" | "num" | "(", expr, ")" ;
 ```


### PR DESCRIPTION
The current EBNF description requires expressions to start with an identifier or a token type of 'OP1'. This change will fix the description to allow languages that have expressions starting with a term. I also added some quotes to the last line with the parenthesis since the parser is looking for literal quotes and it's not just used as EBNF grouping here