### PR TITLE
Fix safe_malloc infinite recursion and use safe_malloc

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -1,10 +1,11 @@
 #include <stdlib.h>
 
 #include "ast.h"
+#include "func.h"
 
 struct Node *make_node(int type, struct Node *op1, struct Node *op2, int val)
 {
-    struct Node *node = malloc(sizeof(struct Node));
+    struct Node *node = safe_malloc(sizeof(struct Node));
     node->type = type;
     node->val = val;
     node->op1 = op1;

--- a/src/func.c
+++ b/src/func.c
@@ -5,8 +5,8 @@
 
 void *safe_malloc(size_t size)
 {
-    void *mem = safe_malloc(size);
-    if (!mem)
+    void *const mem = malloc(size);
+    if (size != 0 && !mem)
         fatal_error("Out of memory");
     return mem;
 }

--- a/src/lex.c
+++ b/src/lex.c
@@ -38,7 +38,7 @@ struct Token lex()
         default: 
             // ID
             if (isalpha(ch)) {
-                char *id_name = malloc(MAX_LEN);
+                char *id_name = safe_malloc(MAX_LEN);
                 int len = 0;
                 id_name[len++] = ch;
                 do {

--- a/src/parser.c
+++ b/src/parser.c
@@ -47,7 +47,7 @@ static void expect(int type)
 
 static struct Node *factor()
 {
-    struct Node* node = malloc(sizeof(struct Node));
+    struct Node* node = safe_malloc(sizeof(struct Node));
     node->op1 = NULL;
     node->op2 = NULL;
 
@@ -90,7 +90,7 @@ static struct Node *expr()
 
     int tok_attr = tok.attr;
     if (accept_two(ID, EQ)) {
-        node = malloc(sizeof(struct Node));
+        node = safe_malloc(sizeof(struct Node));
         node->type = SET_TYPE;
         node->op1 = make_node(VAR_TYPE, 0, 0, tok_attr);
         node->op2 = expr();
@@ -110,7 +110,7 @@ static struct Node *expr()
 
 struct Node *produce()
 {
-    struct Node* node = malloc(sizeof(struct Node));
+    struct Node* node = safe_malloc(sizeof(struct Node));
     node->op1 = expr();
     node->op2 = NULL;
 

--- a/src/sym.c
+++ b/src/sym.c
@@ -2,6 +2,7 @@
 #include <string.h>
 
 #include "sym.h"
+#include "func.h"
 
 struct Table* symbol_table[MAX_SYMBOL_TABLE_SIZE];
 int table_size = 0;
@@ -19,7 +20,7 @@ int add_sym(char *name)
             return symbol_table[i]->id;
     }
 
-    struct Table *item = malloc(sizeof(struct Table));
+    struct Table *item = safe_malloc(sizeof(struct Table));
     item->id = table_size;
     item->name = name;
 


### PR DESCRIPTION
Fix `safe_malloc` infinite recursion and use `safe_malloc` in place of `malloc`

Calling `safe_malloc` would cause `Segmentation fault (core dumped)` because it had infinite recursion previously.

Related to issue #6 